### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -67,15 +67,15 @@ def readRawFile(fileName, db, cursor):
     reader = pd.read_table(filePath, chunksize=CHUNKSIZE, sep=",", encoding='utf-8')
 
     result = getItemsCount(db, cursor)
-    print ("There are %d rows of data" % (result))
+    print ("There are {0:d} rows of data".format((result)))
 
     print("Start import data to MySQL server...")
     for df in reader:
         # process each data frame
         result += process_frame(df, db, cursor)
-        print("FUWebLog: Imported %d records" % result)
+        print("FUWebLog: Imported {0:d} records".format(result))
 
-    print ("There are %d rows of data" % (result))
+    print ("There are {0:d} rows of data".format((result)))
 
 def process_frame(df, db, cursor):
     # process data frame


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:McNoah:Educational-Data-Mining?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:McNoah:Educational-Data-Mining?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)